### PR TITLE
fixes image upload url for self hosted website

### DIFF
--- a/app/initializers/environment.js
+++ b/app/initializers/environment.js
@@ -85,7 +85,10 @@ export default {
     buildEnv.set('building', false);
     buildEnv.set('selfHosted', window.ENV.selfHosted);
 
-    window.ENV.siteDNS = siteName + '.webhook.org';
+    if (!window.ENV.selfHosted)
+    {
+      window.ENV.siteDNS = siteName + '.webhook.org';
+    }
     window.ENV.firebaseRoot.child('/management/sites/' + siteName + '/dns').on('value', function (snap) {
       if (snap.val()) {
         window.ENV.siteDNS = snap.val();


### PR DESCRIPTION
Fixes https://github.com/webhook/webhook-server-open/issues/5 

In cms.html there's this bit of code : 

``` javascript
 {% if firebase_conf.custom %}
  <script>
   window.ENV = {
      dbName:     "{{ firebase_conf.firebase }}",
      uploadUrl:  "{{ firebase_conf.server }}",
      embedlyKey: "{{ firebase_conf.embedly }}",
      siteDNS: "www.example.com",
      selfHosted: true
    };
  </script>
  {% else %}
  <script src="//dl1d2m8ri9v3j.cloudfront.net/releases/1.2.4/tracker.js" data-customer="2ec590caf8d5471a9514fd30e698cea6"></script>
  {% endif %}
```

which sets up a window.ENV object with some required values for self-hosting. However, in environment.js the `window.ENV.siteDNS` value was being overridden and simply performing a check for `!window.ENV.selfHosted` fixes that issue while maintaining backwards compatibility. 
