### PR TITLE
Changed default generation logic so as to avoid generating known duplicate labels

### DIFF
--- a/app/controllers/form.js
+++ b/app/controllers/form.js
@@ -134,12 +134,22 @@ export default Ember.ObjectController.extend(Ember.Evented, {
 
     controls = this.get('model.controls');
 
-    var dupeNamesCount = controls.filterBy('label', controlType.get('name')).get('length');
-
     var label = controlType.get('name');
 
-    if (dupeNamesCount) {
-      label = label + ' ' + (dupeNamesCount + 1);
+    var dupeNameControls = controls.filter(function (control) {
+      return control.get('label').search(new RegExp('^' + label + '(?: \\d+)?$')) === 0;
+    });
+
+    if (dupeNameControls.get('length') > 0) {
+      var highestDupe = dupeNameControls.reduce(function (previousNumber, item) {
+        var currentNumber = parseInt(item.get('label').match(/\d+$/), 10);
+        if (isNaN(currentNumber)) {
+          return previousNumber;
+        } else {
+           return Math.max(previousNumber, currentNumber);
+        }
+      }, 1);
+      label = label + ' ' + (highestDupe + 1);
     }
 
     control = this.store.createRecord('control', {


### PR DESCRIPTION
I noticed that, if you repeatedly added fields to a form without renaming them, then the default label generation logic was resulting in a list like:
- Single line text
- Single line text 2
- Single line text 2
- Single line text 2

Which prevents you from saving the form without making manual edits.

So, since it's a relatively small thing, I thought I'd take a crack at improving this myself rather than just bug reporting it. 

Originally I just changed the filterBy() to look for labels which _started with_ the default name but that could still result in dupes if you deleted fields from the middle of the list and then added another one. This is why it's now a bit more complicated. addControl() will look for the current highest numbered default field label and will add one to that number to generate its own default label.

The one thing this currently doesn't cope with is fields where you've completely deleted the label. Should you even be able to save a form where fields have no label though?
