### PR TITLE
Add option to block javascript in wysiwyg.

### DIFF
--- a/app/components/redactor-rte.js
+++ b/app/components/redactor-rte.js
@@ -61,7 +61,20 @@ export default Ember.Component.extend({
       }
     });
 
-    rte.webhookRedactor();
+    var redactorOptions = {};
+
+    // Attempt to block scripting
+    if (this.get('options.javascript') === false) {
+      redactorOptions.deniedTags = ['script'];
+      redactorOptions.allowedAttr =  [
+        ['a', ['href']],
+        ['p', 'class'],
+        ['img', ['src', 'alt']],
+        ['figure', ['data-type', 'class']]
+      ];
+    }
+
+    rte.webhookRedactor(redactorOptions);
 
     var whRedactor = rte.webhookRedactor('core.getObject');
     this.set('whRedactor', whRedactor);

--- a/app/components/redactor-rte.js
+++ b/app/components/redactor-rte.js
@@ -35,7 +35,14 @@ export default Ember.Component.extend({
         }
 
         if (self.get('value')) {
-          redactor.code.set(self.get('value'));
+          // explicitly check for false (null means yes)
+          if (self.get('options.javascript') === false) {
+            redactor.insert.html(self.get('value'));
+          } else {
+            // redactor.insert.html(self.get('value'), false); should work but it doesn't
+            // perhaps redactor version too old
+            redactor.code.set(self.get('value'));
+          }
         }
 
         rte.on('mutate.webhookRedactor', function (event, redactor) {
@@ -63,7 +70,6 @@ export default Ember.Component.extend({
 
     var redactorOptions = {};
 
-    // Attempt to block scripting
     if (this.get('options.javascript') === false) {
       redactorOptions.deniedTags = ['script'];
       redactorOptions.allowedAttr =  [

--- a/app/controllers/form.js
+++ b/app/controllers/form.js
@@ -212,7 +212,8 @@ export default Ember.ObjectController.extend(Ember.Evented, {
           link : true,
           quote: true,
           table: true,
-          video: true
+          video: true,
+          javascript: true
         });
         break;
       case 'rating':
@@ -1067,6 +1068,12 @@ export default Ember.ObjectController.extend(Ember.Evented, {
 
       if (!control.get('meta')) {
         control.set('meta', Ember.Object.create());
+      }
+
+      // We defaulted to allow javascript for a long time
+      // On sites missing this meta option, default to true.
+      if (control.get('controlType.id') === 'wysiwyg' && control.get('meta.javascript') !== false) {
+        control.set('meta.javascript', true);
       }
 
       this.set('editingControl', control);

--- a/app/templates/components/redactor-rte.hbs
+++ b/app/templates/components/redactor-rte.hbs
@@ -1,4 +1,4 @@
-{{textarea id=id placeholder=placeholder value=value disabled=disabled}}
+{{textarea id=id placeholder=placeholder disabled=disabled}}
 
 {{webhook-modal
   show=showImageModal

--- a/app/templates/widgets/info/_wysiwyg.hbs
+++ b/app/templates/widgets/info/_wysiwyg.hbs
@@ -33,6 +33,10 @@
       {{input type="checkbox" checked=editingControl.meta.link}}
       Links
     </label>
+    <label class="wy-checkbox">
+      {{input type="checkbox" checked=editingControl.meta.javascript}}
+      JavaScript
+    </label>
   </div>
 
 </div>


### PR DESCRIPTION
If a developer decides that they do not want WYSIWYG users to use JavaScript in the editor, attempt to strip related tags and attributes.