### PR TITLE
Escape query when creating relation.

### DIFF
--- a/app/views/auto-complete.js
+++ b/app/views/auto-complete.js
@@ -26,9 +26,10 @@ export default Ember.TextField.extend({
           return Ember.Object.create(result);
         });
         if (canCreate) {
+          var escapedQuery = Ember.Handlebars.Utils.escapeExpression(query);
           results.addObject(Ember.Object.create({
-            name: 'Create "%@"'.fmt(Ember.Handlebars.Utils.escapeExpression(query)),
-            value: query,
+            name: 'Create "%@"'.fmt(escapedQuery),
+            value: escapedQuery,
             createStub: true,
             type: type
           }));

--- a/app/views/auto-complete.js
+++ b/app/views/auto-complete.js
@@ -27,7 +27,7 @@ export default Ember.TextField.extend({
         });
         if (canCreate) {
           results.addObject(Ember.Object.create({
-            name: 'Create "%@"'.fmt(query),
+            name: 'Create "%@"'.fmt(Ember.Handlebars.Utils.escapeExpression(query)),
             value: query,
             createStub: true,
             type: type


### PR DESCRIPTION
Escape query when creating a new item through the autocompleter.

![image](https://cloud.githubusercontent.com/assets/8754/7877739/a8ea7810-0593-11e5-8496-55f5a54deeb3.png)
