### PR TITLE
Supports a "full" imageCommand in the redactor component

### DIFF
--- a/app/components/redactor-rte.js
+++ b/app/components/redactor-rte.js
@@ -158,6 +158,9 @@ export default Ember.Component.extend({
       case 'large':
         size = 1200;
         break;
+      case 'full':
+        size = 0;
+        break;
       }
 
       if (size) {

--- a/app/components/redactor-rte.js
+++ b/app/components/redactor-rte.js
@@ -146,7 +146,7 @@ export default Ember.Component.extend({
     var self = this;
     this.get('whRedactor').$editor.on('imageCommand', 'figure', function (event, command) {
 
-      var size;
+      var size = null;
 
       switch (command) {
       case 'small':
@@ -163,7 +163,7 @@ export default Ember.Component.extend({
         break;
       }
 
-      if (size) {
+      if (size !== null) {
         var url = $(this).find('img').attr('data-resize-src'),
             resizeUrl = self.resizeImage(url, size);
         $(this).find('img').attr('src', resizeUrl);

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.2",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "webhook-js": "*",
-    "webhook-redactor": "webhook/webhook-redactor",
+    "webhook-redactor": "mshick/webhook-redactor",
     "firebase": "2.0.x",
     "firebase-simple-login": "1.6.x",
     "embedly-jquery": "~3.1.1",

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.2",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "webhook-js": "*",
-    "webhook-redactor": "mshick/webhook-redactor",
+    "webhook-redactor": "webhook/webhook-redactor",
     "firebase": "2.0.x",
     "firebase-simple-login": "1.6.x",
     "embedly-jquery": "~3.1.1",


### PR DESCRIPTION
The `full` command will pass through `s=0` which results in an image with native dimensions.
