### PR TITLE
adding max-height to relationship autocomplete.

### DIFF
--- a/app/styles/_app_form_controls.sass
+++ b/app/styles/_app_form_controls.sass
@@ -251,3 +251,8 @@ input[type=color]
   margin-right: 0.3em
   &.ui-sortable-helper .wy-tag-remove
     display: none
+
+.wy-autocomplete-dropdown
+  max-height: 13em
+  overflow: auto
+  


### PR DESCRIPTION
Hi I have added a max-height to the relationship autocomplete field, to prevent a large amount of result from scrolling off the bottom of the page. This prevented me from being able to create new stubs. This is a css fix, but I'll look into creating ignored common words, such as 'the', to help cut down the returned results.
